### PR TITLE
このアクションを末永く使えるように、dependabot設定+バージョン更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  open-pull-requests-limit: 10
+  schedule:
+    interval: monthly
+  groups:
+    github-actions:
+      patterns: ["*"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get PocketMine-MP version
         id: pmmp_version
@@ -27,7 +27,7 @@ jobs:
           store PM_VERSION $PM_VERSION
           store CHANGELOG $CHANGELOG
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache
         with:
           path: version_cache


### PR DESCRIPTION
VRChatに忙しい中失礼します。
動作確認済みです。

このインストーラはめちゃくちゃ素晴らしく、Github側の都合で勝手に壊れてほしくないので、dependabot設定しました。

してほしいこと
ここに行き、
https://github.com/Nerahikada/PocketMine-MP_Installer/settings/security_analysis

- Dependabot rulesを0件にする
- ルールをこんな感じにする
<img width="805" height="588" alt="image" src="https://github.com/user-attachments/assets/9ecf3413-56c9-4f43-af48-1d1e576839ce" />

あとは1か月に1回、更新がある場合はpull requestが送られてくるので、スカッシュマージしてください。